### PR TITLE
Refactor auth context and stabilize item filtering

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react'
+
+export const AuthContext = createContext(null)
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
+  return ctx
+}

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -1,7 +1,6 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { authService } from '../services/authService'
-
-const AuthContext = createContext(null)
+import { AuthContext } from './AuthContext'
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
@@ -93,11 +92,3 @@ export function AuthProvider({ children }) {
     <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
   )
 }
-
-export function useAuth() {
-  const ctx = useContext(AuthContext)
-  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
-  return ctx
-}
-
-

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { GoogleOAuthProvider } from '@react-oauth/google'
-import { AuthProvider } from './context/AuthContext'
+import { AuthProvider } from './context/AuthProvider'
 import './index.css'
 import App from './App.jsx'
 import 'bootstrap/dist/css/bootstrap.min.css';

--- a/src/pages/CoffeeManagement.jsx
+++ b/src/pages/CoffeeManagement.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { 
   Container, 
   Row, 
@@ -52,25 +52,7 @@ export default function CoffeeManagement() {
     fetchCoffeeItems()
   }, [])
 
-  // Filter items when search or category changes
-  useEffect(() => {
-    filterItems()
-  }, [coffeeItems, searchTerm, categoryFilter])
-
-  const fetchCoffeeItems = async () => {
-    try {
-      setLoading(true)
-      setError('')
-      const data = await coffeeService.getAllCoffeeItems()
-      setCoffeeItems(data)
-    } catch (err) {
-      setError(err.message)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const filterItems = () => {
+  const filterItems = useCallback(() => {
     let filtered = coffeeItems
 
     // Filter by search term
@@ -88,7 +70,27 @@ export default function CoffeeManagement() {
     }
 
     setFilteredItems(filtered)
+  }, [coffeeItems, searchTerm, categoryFilter])
+
+  // Filter items when search or category changes
+  useEffect(() => {
+    filterItems()
+  }, [filterItems])
+
+  const fetchCoffeeItems = async () => {
+    try {
+      setLoading(true)
+      setError('')
+      const data = await coffeeService.getAllCoffeeItems()
+      setCoffeeItems(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
   }
+
+  
 
   const handleEdit = (coffee) => {
     setSelectedCoffee(coffee)


### PR DESCRIPTION
## Summary
- Split AuthContext into separate provider and hook modules to satisfy fast-refresh requirements
- Refactor CoffeeManagement filtering logic with useCallback for proper dependency tracking
- Update application entry to import the new AuthProvider module

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad6a624438833098fc943fe0c6c567