### PR TITLE
Remove Google login support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "coffee-subscription-web",
       "version": "0.0.0",
       "dependencies": {
-        "@react-oauth/google": "^0.12.2",
         "axios": "^1.11.0",
         "bootstrap": "^5.3.7",
         "react": "^19.1.1",
@@ -1058,16 +1057,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-oauth/google": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
-      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@restart/hooks": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@react-oauth/google": "^0.12.2",
     "axios": "^1.11.0",
     "bootstrap": "^5.3.7",
     "react": "^19.1.1",

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -36,19 +36,6 @@ export function AuthProvider({ children }) {
     }
   }, [])
 
-  const signInWithGoogle = useCallback(async (googleToken) => {
-    try {
-      const { token: newToken, user: authedUser } = await authService.signInWithGoogle(googleToken)
-      localStorage.setItem('auth_token', newToken)
-      localStorage.setItem('auth_user', JSON.stringify(authedUser))
-      setToken(newToken)
-      setUser(authedUser)
-      return authedUser
-    } catch (error) {
-      console.error('Google sign in error:', error)
-      throw error
-    }
-  }, [])
 
   const signUp = useCallback(async (name, email, password) => {
     try {
@@ -85,8 +72,7 @@ export function AuthProvider({ children }) {
     signIn,
     signUp,
     signOut,
-    signInWithGoogle,
-  }), [user, token, isInitializing, signIn, signUp, signOut, signInWithGoogle])
+  }), [user, token, isInitializing, signIn, signUp, signOut])
 
   return (
     <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import { GoogleOAuthProvider } from '@react-oauth/google'
 import { AuthProvider } from './context/AuthProvider'
 import './index.css'
 import App from './App.jsx'
@@ -9,12 +8,10 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <GoogleOAuthProvider clientId="1066881971225-f2467gvl2pl7bmn4hkqaejriks6it6ee.apps.googleusercontent.com">
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </BrowserRouter>
-    </GoogleOAuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -2,35 +2,15 @@ import { useState } from 'react'
 import { Form, Button, Card, Alert, Spinner } from 'react-bootstrap'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
-import { GoogleLogin } from '@react-oauth/google'
 
 export default function SignIn() {
-  const { signIn, signInWithGoogle } = useAuth()
+  const { signIn } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
-  const [googleLoading, setGoogleLoading] = useState(false)
-
-  const handleGoogleSuccess = async (credentialResponse) => {
-    setError('')
-    setGoogleLoading(true)
-    try {
-      await signInWithGoogle(credentialResponse.credential)
-      const redirectTo = location.state?.from || '/'
-      navigate(redirectTo)
-    } catch (err) {
-      setError(err?.message || 'Google sign in failed')
-    } finally {
-      setGoogleLoading(false)
-    }
-  }
-
-  const handleGoogleError = () => {
-    setError('Google sign in failed')
-  }
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -67,16 +47,6 @@ export default function SignIn() {
             </Button>
           </div>
         </Form>
-        <div className="my-3 text-center">
-          <GoogleLogin
-            onSuccess={handleGoogleSuccess}
-            onError={handleGoogleError}
-            width="340"
-            theme="outline"
-            size="large"
-          />
-          {googleLoading && <Spinner animation="border" size="sm" className="me-2" />}<span>{googleLoading ? 'Signing in with Google…' : ''}</span>
-        </div>
         <div className="mt-3">
           New here? <Link to="/signup">Create an account</Link>
         </div>

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -101,21 +101,6 @@ export const authService = {
     }
   },
 
-  signInWithGoogle: async (googleToken) => {
-    try {
-      const response = await api.post('/api/Auth/google-login', { token: googleToken })
-      if (!response.data.success || !response.data.data?.token) {
-        throw new Error('Google login failed')
-      }
-      return {
-        token: response.data.data.token,
-        user: response.data.data.user || { provider: 'google' }
-      }
-    } catch (error) {
-      handleError(error)
-    }
-  },
-
   signOut: () => {
     localStorage.removeItem('auth_token')
     return true


### PR DESCRIPTION
## Summary
- remove Google OAuth provider and login flows
- strip Google sign-in from auth context and service
- clean up SignIn page and dependencies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad7898df808330aca3c0528e5f012c