### PR TITLE
feat: add user management API integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import SubscriptionPlanPage from './pages/SubscriptionPlanPage'
 import SubscriptionPlanDetail from './pages/SubscriptionPlanDetail'
 import Dashboard from './pages/Dashboard'
 import DashboardLayout from './components/DashboardLayout'
+import UserManagement from './pages/UserManagement'
 import './App.css'
 
 export default function App() {
@@ -21,6 +22,7 @@ export default function App() {
       >
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/coffee-management" element={<CoffeeManagement />} />
+        <Route path="/users" element={<UserManagement />} />
         <Route path="/subscription-plans" element={<SubscriptionPlanPage />} />
         <Route path="/subscription-plans/:id" element={<SubscriptionPlanDetail />} />
       </Route>

--- a/src/pages/UserManagement.jsx
+++ b/src/pages/UserManagement.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react'
+import {
+  Container,
+  Card,
+  Table,
+  Button,
+  Form,
+  InputGroup,
+  Modal,
+  Spinner,
+  Alert
+} from 'react-bootstrap'
+import { userService } from '../services/userService'
+
+export default function UserManagement() {
+  const [users, setUsers] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [searchTerm, setSearchTerm] = useState('')
+  const [selectedUser, setSelectedUser] = useState(null)
+  const [showDetail, setShowDetail] = useState(false)
+
+  useEffect(() => {
+    fetchUsers()
+  }, [])
+
+  const fetchUsers = async () => {
+    try {
+      setLoading(true)
+      setError('')
+      const data = await userService.getUsers()
+      setUsers(data || [])
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSearch = async (e) => {
+    e.preventDefault()
+    try {
+      setLoading(true)
+      setError('')
+      const data = await userService.searchUsers(searchTerm)
+      setUsers(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleViewDetails = async (id) => {
+    try {
+      setError('')
+      const data = await userService.getUserById(id)
+      setSelectedUser(data)
+      setShowDetail(true)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const handleToggleActive = async (user) => {
+    try {
+      await userService.setUserActive(user.id, !user.isActive)
+      const updated = await userService.getUserById(user.id)
+      setUsers(prev => prev.map(u => (u.id === user.id ? updated : u)))
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <Container>
+      <h2 className="mb-4">User Management</h2>
+
+      <Card className="mb-4">
+        <Card.Body>
+          <Form onSubmit={handleSearch}>
+            <InputGroup>
+              <Form.Control
+                placeholder="Search users..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
+              <Button type="submit">Search</Button>
+              <Button variant="secondary" onClick={fetchUsers}>Reset</Button>
+            </InputGroup>
+          </Form>
+        </Card.Body>
+      </Card>
+
+      {error && <Alert variant="danger">{error}</Alert>}
+
+      {loading ? (
+        <div className="text-center">
+          <Spinner animation="border" />
+        </div>
+      ) : (
+        <Card>
+          <Card.Body>
+            <Table striped bordered hover responsive>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Username</th>
+                  <th>Full Name</th>
+                  <th>Email</th>
+                  <th>Phone</th>
+                  <th>Active</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id}>
+                    <td>{user.id}</td>
+                    <td>{user.username}</td>
+                    <td>{user.fullName}</td>
+                    <td>{user.email}</td>
+                    <td>{user.phoneNumber}</td>
+                    <td>
+                      <Form.Check
+                        type="switch"
+                        checked={user.isActive}
+                        onChange={() => handleToggleActive(user)}
+                      />
+                    </td>
+                    <td>
+                      <Button
+                        size="sm"
+                        variant="info"
+                        onClick={() => handleViewDetails(user.id)}
+                      >
+                        View Details
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Card.Body>
+        </Card>
+      )}
+
+      <Modal show={showDetail} onHide={() => setShowDetail(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>User Details</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {selectedUser && (
+            <>
+              <p><strong>ID:</strong> {selectedUser.id}</p>
+              <p><strong>Username:</strong> {selectedUser.username}</p>
+              <p><strong>Full Name:</strong> {selectedUser.fullName}</p>
+              <p><strong>Email:</strong> {selectedUser.email}</p>
+              <p><strong>Phone:</strong> {selectedUser.phoneNumber}</p>
+              <p><strong>Role:</strong> {selectedUser.role}</p>
+              <p><strong>Active:</strong> {selectedUser.isActive ? 'Yes' : 'No'}</p>
+              <p><strong>Created At:</strong> {selectedUser.createdAt}</p>
+              <p><strong>Updated At:</strong> {selectedUser.updatedAt}</p>
+            </>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowDetail(false)}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </Container>
+  )
+}

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,52 @@
+import { api } from '../utils/axiosConfig'
+
+export const userService = {
+  getUsers: async () => {
+    try {
+      const response = await api.get('/api/User')
+      return response.data.data
+    } catch (error) {
+      console.error('Error fetching users:', error)
+      throw new Error('Failed to fetch users.')
+    }
+  },
+
+  searchUsers: async (keyword, isDelete = false, pageNum = 0, pageSize = 10) => {
+    try {
+      const payload = {
+        searchCondition: {
+          keyword,
+          isDelete
+        },
+        pageInfo: {
+          pageNum,
+          pageSize
+        }
+      }
+      const response = await api.post('/api/User/search', payload)
+      return response.data.data?.pageData || []
+    } catch (error) {
+      console.error('Error searching users:', error)
+      throw new Error('Failed to search users.')
+    }
+  },
+
+  getUserById: async (id) => {
+    try {
+      const response = await api.get(`/api/User/${id}`)
+      return response.data.data
+    } catch (error) {
+      console.error('Error fetching user:', error)
+      throw new Error('Failed to fetch user details.')
+    }
+  },
+
+  setUserActive: async (id, active) => {
+    try {
+      await api.put(`/api/User/is-active/${id}?active=${active}`)
+    } catch (error) {
+      console.error('Error updating user status:', error)
+      throw new Error('Failed to update user status.')
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement user service with list, search, detail, and active status endpoints
- build User Management page with search, detail modal, and active status toggle
- route /users through App routing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad895bebac8330a2a7a237d7dc2dbf