### PR TITLE
Align subscription plan endpoints

### DIFF
--- a/src/services/subscriptionPlanService.js
+++ b/src/services/subscriptionPlanService.js
@@ -3,7 +3,7 @@ import { api } from '../utils/axiosConfig'
 export const subscriptionPlanService = {
   getAllPlans: async () => {
     try {
-      const response = await api.get('/api/SubscriptionPlan/getAll')
+      const response = await api.get('/api/SubscriptionPlan')
       return response.data
     } catch (error) {
       console.error('Error fetching subscription plans:', error)
@@ -23,7 +23,7 @@ export const subscriptionPlanService = {
 
   createPlan: async (planData) => {
     try {
-      const response = await api.post('/api/SubscriptionPlan/create', planData)
+      const response = await api.post('/api/SubscriptionPlan', planData)
       return response.data
     } catch (error) {
       console.error('Error creating subscription plan:', error)


### PR DESCRIPTION
## Summary
- use `/api/SubscriptionPlan` for listing subscription plans
- send create requests to `/api/SubscriptionPlan`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad9ea34890833080e0996ffcddc48f