### PR TITLE
feat: add coffee items page to sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -18,6 +18,9 @@ export default function Sidebar() {
         <Nav.Link as={NavLink} to="/dashboard" end>
           Dashboard
         </Nav.Link>
+        <Nav.Link as={NavLink} to="/coffee-management">
+          Coffee Items
+        </Nav.Link>
         <Nav.Link as={NavLink} to="/users">
           User Management
         </Nav.Link>


### PR DESCRIPTION
## Summary
- add coffee items link to sidebar for easy navigation

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb1273d548330b07f75cad2443a8e