### PR TITLE
Add daily cup tracking page and service

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import DashboardLayout from './components/DashboardLayout'
 import UserManagement from './pages/UserManagement'
 import Subscriptions from './pages/Subscriptions'
 import TimeWindows from './pages/TimeWindows'
+import DailyCupTracking from './pages/DailyCupTracking'
 import './App.css'
 
 export default function App() {
@@ -29,6 +30,7 @@ export default function App() {
         <Route path="/subscription-plans" element={<SubscriptionPlanPage />} />
         <Route path="/subscription-plans/:id" element={<SubscriptionPlanDetail />} />
         <Route path="/time-windows" element={<TimeWindows />} />
+        <Route path="/daily-cup-tracking" element={<DailyCupTracking />} />
       </Route>
     </Routes>
   )

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -33,6 +33,9 @@ export default function Sidebar() {
         <Nav.Link as={NavLink} to="/time-windows">
           Time Windows
         </Nav.Link>
+        <Nav.Link as={NavLink} to="/daily-cup-tracking">
+          Daily Cup Tracking
+        </Nav.Link>
       </Nav>
       <Button variant="outline-danger" className="mt-auto" onClick={handleLogout}>
         Logout

--- a/src/pages/DailyCupTracking.jsx
+++ b/src/pages/DailyCupTracking.jsx
@@ -1,0 +1,296 @@
+import React, { useEffect, useState } from 'react'
+import { Container, Button, Table, Spinner, Alert, Modal, Form } from 'react-bootstrap'
+import { dailyCupTrackingService } from '../services/dailyCupTrackingService'
+
+const initialForm = {
+  subscriptionId: '',
+  date: '',
+  cupsTaken: ''
+}
+
+export default function DailyCupTracking() {
+  const [trackings, setTrackings] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const [showCreate, setShowCreate] = useState(false)
+  const [createForm, setCreateForm] = useState(initialForm)
+  const [createLoading, setCreateLoading] = useState(false)
+  const [createError, setCreateError] = useState('')
+
+  const [showEdit, setShowEdit] = useState(false)
+  const [editForm, setEditForm] = useState(initialForm)
+  const [editLoading, setEditLoading] = useState(false)
+  const [editError, setEditError] = useState('')
+  const [editing, setEditing] = useState(null)
+
+  const [showDelete, setShowDelete] = useState(false)
+  const [deleting, setDeleting] = useState(null)
+  const [deleteError, setDeleteError] = useState('')
+
+  useEffect(() => {
+    fetchTrackings()
+  }, [])
+
+  const fetchTrackings = async () => {
+    try {
+      setLoading(true)
+      const data = await dailyCupTrackingService.getAll()
+      setTrackings(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCreateChange = (e) => {
+    const { name, value } = e.target
+    setCreateForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleCreateSubmit = async (e) => {
+    e.preventDefault()
+    setCreateLoading(true)
+    setCreateError('')
+    try {
+      await dailyCupTrackingService.create(createForm)
+      setShowCreate(false)
+      setCreateForm(initialForm)
+      fetchTrackings()
+    } catch (err) {
+      setCreateError(err.message)
+    } finally {
+      setCreateLoading(false)
+    }
+  }
+
+  const openEdit = (item) => {
+    setEditing(item)
+    setEditForm({
+      subscriptionId: item.subscriptionId,
+      date: item.date,
+      cupsTaken: item.cupsTaken
+    })
+    setShowEdit(true)
+    setEditError('')
+  }
+
+  const handleEditChange = (e) => {
+    const { name, value } = e.target
+    setEditForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleEditSubmit = async (e) => {
+    e.preventDefault()
+    setEditLoading(true)
+    setEditError('')
+    try {
+      await dailyCupTrackingService.update(editing.trackingId, editForm)
+      setShowEdit(false)
+      setEditing(null)
+      fetchTrackings()
+    } catch (err) {
+      setEditError(err.message)
+    } finally {
+      setEditLoading(false)
+    }
+  }
+
+  const openDelete = (item) => {
+    setDeleting(item)
+    setDeleteError('')
+    setShowDelete(true)
+  }
+
+  const handleDelete = async () => {
+    if (!deleting) return
+    try {
+      await dailyCupTrackingService.remove(deleting.trackingId)
+      setShowDelete(false)
+      setDeleting(null)
+      fetchTrackings()
+    } catch (err) {
+      setDeleteError(err.message)
+    }
+  }
+
+  return (
+    <Container className="py-4">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2>Daily Cup Tracking</h2>
+        <Button onClick={() => setShowCreate(true)}>Add Tracking</Button>
+      </div>
+
+      {loading ? (
+        <Spinner animation="border" />
+      ) : error ? (
+        <Alert variant="danger">{error}</Alert>
+      ) : (
+        <Table striped bordered hover>
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Subscription ID</th>
+              <th>Date</th>
+              <th>Cups Taken</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {trackings.length > 0 ? (
+              trackings.map((t) => (
+                <tr key={t.trackingId}>
+                  <td>{t.trackingId}</td>
+                  <td>{t.subscriptionId}</td>
+                  <td>{t.date}</td>
+                  <td>{t.cupsTaken}</td>
+                  <td>
+                    <Button
+                      variant="warning"
+                      size="sm"
+                      className="me-2"
+                      onClick={() => openEdit(t)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      onClick={() => openDelete(t)}
+                    >
+                      Delete
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={5} className="text-center">
+                  No records
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      )}
+
+      {/* Create Modal */}
+      <Modal show={showCreate} onHide={() => setShowCreate(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Add Tracking</Modal.Title>
+        </Modal.Header>
+        <Form onSubmit={handleCreateSubmit}>
+          <Modal.Body>
+            {createError && <Alert variant="danger">{createError}</Alert>}
+            <Form.Group className="mb-2">
+              <Form.Label>Subscription ID</Form.Label>
+              <Form.Control
+                name="subscriptionId"
+                value={createForm.subscriptionId}
+                onChange={handleCreateChange}
+                required
+              />
+            </Form.Group>
+            <Form.Group className="mb-2">
+              <Form.Label>Date</Form.Label>
+              <Form.Control
+                type="date"
+                name="date"
+                value={createForm.date}
+                onChange={handleCreateChange}
+                required
+              />
+            </Form.Group>
+            <Form.Group className="mb-2">
+              <Form.Label>Cups Taken</Form.Label>
+              <Form.Control
+                type="number"
+                name="cupsTaken"
+                value={createForm.cupsTaken}
+                onChange={handleCreateChange}
+                required
+              />
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setShowCreate(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" type="submit" disabled={createLoading}>
+              {createLoading ? 'Saving...' : 'Save'}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+
+      {/* Edit Modal */}
+      <Modal show={showEdit} onHide={() => setShowEdit(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Edit Tracking</Modal.Title>
+        </Modal.Header>
+        <Form onSubmit={handleEditSubmit}>
+          <Modal.Body>
+            {editError && <Alert variant="danger">{editError}</Alert>}
+            <Form.Group className="mb-2">
+              <Form.Label>Subscription ID</Form.Label>
+              <Form.Control
+                name="subscriptionId"
+                value={editForm.subscriptionId}
+                onChange={handleEditChange}
+                required
+              />
+            </Form.Group>
+            <Form.Group className="mb-2">
+              <Form.Label>Date</Form.Label>
+              <Form.Control
+                type="date"
+                name="date"
+                value={editForm.date}
+                onChange={handleEditChange}
+                required
+              />
+            </Form.Group>
+            <Form.Group className="mb-2">
+              <Form.Label>Cups Taken</Form.Label>
+              <Form.Control
+                type="number"
+                name="cupsTaken"
+                value={editForm.cupsTaken}
+                onChange={handleEditChange}
+                required
+              />
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setShowEdit(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" type="submit" disabled={editLoading}>
+              {editLoading ? 'Saving...' : 'Save'}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+
+      {/* Delete Modal */}
+      <Modal show={showDelete} onHide={() => setShowDelete(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete Tracking</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {deleteError && <Alert variant="danger">{deleteError}</Alert>}
+          Are you sure you want to delete this tracking?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowDelete(false)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleDelete}>
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </Container>
+  )
+}

--- a/src/services/dailyCupTrackingService.js
+++ b/src/services/dailyCupTrackingService.js
@@ -1,0 +1,43 @@
+import { api } from '../utils/axiosConfig'
+
+export const dailyCupTrackingService = {
+  getAll: async () => {
+    try {
+      const response = await api.get('/api/DailyCupTracking')
+      return response.data?.data || response.data
+    } catch (error) {
+      console.error('Error fetching daily cup tracking:', error)
+      throw new Error(error.response?.data?.message || 'Failed to fetch daily cup tracking')
+    }
+  },
+
+  create: async (data) => {
+    try {
+      const response = await api.post('/api/DailyCupTracking', data)
+      return response.data
+    } catch (error) {
+      console.error('Error creating daily cup tracking:', error)
+      throw new Error(error.response?.data?.message || 'Failed to create daily cup tracking')
+    }
+  },
+
+  update: async (id, data) => {
+    try {
+      const response = await api.put(`/api/DailyCupTracking/${id}`, data)
+      return response.data
+    } catch (error) {
+      console.error('Error updating daily cup tracking:', error)
+      throw new Error(error.response?.data?.message || 'Failed to update daily cup tracking')
+    }
+  },
+
+  remove: async (id) => {
+    try {
+      const response = await api.delete(`/api/DailyCupTracking/${id}`)
+      return response.data
+    } catch (error) {
+      console.error('Error deleting daily cup tracking:', error)
+      throw new Error(error.response?.data?.message || 'Failed to delete daily cup tracking')
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add service for DailyCupTracking API
- create DailyCupTracking page with CRUD actions
- expose DailyCupTracking page in routes and sidebar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adbab5f30c8330bfc836b3693c09f1