### PR TITLE
Add PlanCoffeeOption management page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import UserManagement from './pages/UserManagement'
 import Subscriptions from './pages/Subscriptions'
 import TimeWindows from './pages/TimeWindows'
 import DailyCupTracking from './pages/DailyCupTracking'
+import PlanCoffeeOption from './pages/PlanCoffeeOption'
 import './App.css'
 
 export default function App() {
@@ -30,6 +31,7 @@ export default function App() {
         <Route path="/subscription-plans" element={<SubscriptionPlanPage />} />
         <Route path="/subscription-plans/:id" element={<SubscriptionPlanDetail />} />
         <Route path="/time-windows" element={<TimeWindows />} />
+        <Route path="/plan-coffee-options" element={<PlanCoffeeOption />} />
         <Route path="/daily-cup-tracking" element={<DailyCupTracking />} />
       </Route>
     </Routes>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -30,6 +30,9 @@ export default function Sidebar() {
         <Nav.Link as={NavLink} to="/subscription-plans">
           Subscription Plans
         </Nav.Link>
+        <Nav.Link as={NavLink} to="/plan-coffee-options">
+          Plan Coffee Options
+        </Nav.Link>
         <Nav.Link as={NavLink} to="/time-windows">
           Time Windows
         </Nav.Link>

--- a/src/pages/PlanCoffeeOption.jsx
+++ b/src/pages/PlanCoffeeOption.jsx
@@ -1,0 +1,297 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Container,
+  Table,
+  Button,
+  Spinner,
+  Alert,
+  Modal,
+  Form,
+  Card
+} from 'react-bootstrap'
+import { planCoffeeOptionService } from '../services/planCoffeeOptionService'
+
+const initialForm = {
+  planId: '',
+  coffeeId: ''
+}
+
+export default function PlanCoffeeOption() {
+  const [options, setOptions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const [showCreate, setShowCreate] = useState(false)
+  const [createForm, setCreateForm] = useState(initialForm)
+  const [createLoading, setCreateLoading] = useState(false)
+  const [createError, setCreateError] = useState('')
+
+  const [showEdit, setShowEdit] = useState(false)
+  const [editForm, setEditForm] = useState(initialForm)
+  const [editLoading, setEditLoading] = useState(false)
+  const [editError, setEditError] = useState('')
+  const [editingOption, setEditingOption] = useState(null)
+
+  const [showDelete, setShowDelete] = useState(false)
+  const [deletingOption, setDeletingOption] = useState(null)
+  const [deleteError, setDeleteError] = useState('')
+
+  useEffect(() => {
+    fetchOptions()
+  }, [])
+
+  const fetchOptions = async () => {
+    try {
+      setLoading(true)
+      const data = await planCoffeeOptionService.getAll()
+      setOptions(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCreateChange = (e) => {
+    const { name, value } = e.target
+    setCreateForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleCreateSubmit = async (e) => {
+    e.preventDefault()
+    setCreateLoading(true)
+    setCreateError('')
+    try {
+      await planCoffeeOptionService.create({
+        planId: Number(createForm.planId),
+        coffeeId: Number(createForm.coffeeId)
+      })
+      setShowCreate(false)
+      setCreateForm(initialForm)
+      fetchOptions()
+    } catch (err) {
+      setCreateError(err.message)
+    } finally {
+      setCreateLoading(false)
+    }
+  }
+
+  const openEdit = async (optionId) => {
+    try {
+      const data = await planCoffeeOptionService.getById(optionId)
+      setEditingOption(data)
+      setEditForm({
+        planId: data.planId || '',
+        coffeeId: data.coffeeId || ''
+      })
+      setShowEdit(true)
+      setEditError('')
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const handleEditChange = (e) => {
+    const { name, value } = e.target
+    setEditForm(prev => ({ ...prev, [name]: value }))
+  }
+
+  const handleEditSubmit = async (e) => {
+    e.preventDefault()
+    if (!editingOption) return
+    setEditLoading(true)
+    setEditError('')
+    try {
+      await planCoffeeOptionService.update(editingOption.optionId, {
+        planId: Number(editForm.planId),
+        coffeeId: Number(editForm.coffeeId)
+      })
+      setShowEdit(false)
+      setEditingOption(null)
+      fetchOptions()
+    } catch (err) {
+      setEditError(err.message)
+    } finally {
+      setEditLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deletingOption) return
+    try {
+      await planCoffeeOptionService.remove(deletingOption.optionId)
+      setShowDelete(false)
+      setDeletingOption(null)
+      fetchOptions()
+    } catch (err) {
+      setDeleteError(err.message)
+    }
+  }
+
+  return (
+    <Container className="py-4">
+      <Card>
+        <Card.Header className="d-flex justify-content-between align-items-center">
+          <h5 className="mb-0">Plan Coffee Options</h5>
+          <Button onClick={() => setShowCreate(true)}>Add Option</Button>
+        </Card.Header>
+        <Card.Body>
+          {loading ? (
+            <div className="text-center">
+              <Spinner animation="border" />
+            </div>
+          ) : error ? (
+            <Alert variant="danger">{error}</Alert>
+          ) : (
+            <Table bordered hover>
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Plan ID</th>
+                  <th>Coffee ID</th>
+                  <th>Active</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {options && options.length > 0 ? (
+                  options.map((opt) => (
+                    <tr key={opt.optionId}>
+                      <td>{opt.optionId}</td>
+                      <td>{opt.planId}</td>
+                      <td>{opt.coffeeId}</td>
+                      <td>{opt.isActive ? 'Yes' : 'No'}</td>
+                      <td>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          className="me-2"
+                          onClick={() => openEdit(opt.optionId)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="danger"
+                          onClick={() => {
+                            setDeletingOption(opt)
+                            setShowDelete(true)
+                            setDeleteError('')
+                          }}
+                        >
+                          Delete
+                        </Button>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={5} className="text-center">
+                      No options found
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </Table>
+          )}
+        </Card.Body>
+      </Card>
+
+      {/* Create Modal */}
+      <Modal show={showCreate} onHide={() => setShowCreate(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Create Plan Coffee Option</Modal.Title>
+        </Modal.Header>
+        <Form onSubmit={handleCreateSubmit}>
+          <Modal.Body>
+            {createError && <Alert variant="danger">{createError}</Alert>}
+            <Form.Group className="mb-3">
+              <Form.Label>Plan ID</Form.Label>
+              <Form.Control
+                name="planId"
+                value={createForm.planId}
+                onChange={handleCreateChange}
+                required
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Coffee ID</Form.Label>
+              <Form.Control
+                name="coffeeId"
+                value={createForm.coffeeId}
+                onChange={handleCreateChange}
+                required
+              />
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setShowCreate(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={createLoading}>
+              {createLoading ? 'Saving...' : 'Save'}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+
+      {/* Edit Modal */}
+      <Modal show={showEdit} onHide={() => setShowEdit(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Edit Plan Coffee Option</Modal.Title>
+        </Modal.Header>
+        <Form onSubmit={handleEditSubmit}>
+          <Modal.Body>
+            {editError && <Alert variant="danger">{editError}</Alert>}
+            <Form.Group className="mb-3">
+              <Form.Label>Plan ID</Form.Label>
+              <Form.Control
+                name="planId"
+                value={editForm.planId}
+                onChange={handleEditChange}
+                required
+              />
+            </Form.Group>
+            <Form.Group>
+              <Form.Label>Coffee ID</Form.Label>
+              <Form.Control
+                name="coffeeId"
+                value={editForm.coffeeId}
+                onChange={handleEditChange}
+                required
+              />
+            </Form.Group>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setShowEdit(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={editLoading}>
+              {editLoading ? 'Saving...' : 'Save'}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+
+      {/* Delete Modal */}
+      <Modal show={showDelete} onHide={() => setShowDelete(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Delete Plan Coffee Option</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {deleteError && <Alert variant="danger">{deleteError}</Alert>}
+          Are you sure you want to delete this option?
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowDelete(false)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleDelete}>
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </Container>
+  )
+}
+

--- a/src/services/planCoffeeOptionService.js
+++ b/src/services/planCoffeeOptionService.js
@@ -1,0 +1,64 @@
+import { api } from '../utils/axiosConfig'
+
+export const planCoffeeOptionService = {
+  getAll: async () => {
+    try {
+      const response = await api.get('/api/PlanCoffeeOption')
+      return response.data?.data || response.data
+    } catch (error) {
+      console.error('Error fetching plan coffee options:', error)
+      throw new Error(
+        error.response?.data?.message || 'Failed to fetch plan coffee options'
+      )
+    }
+  },
+
+  getById: async (id) => {
+    try {
+      const response = await api.get(`/api/PlanCoffeeOption/${id}`)
+      return response.data?.data || response.data
+    } catch (error) {
+      console.error('Error fetching plan coffee option:', error)
+      throw new Error(
+        error.response?.data?.message || 'Failed to fetch plan coffee option'
+      )
+    }
+  },
+
+  create: async (data) => {
+    try {
+      const response = await api.post('/api/PlanCoffeeOption', data)
+      return response.data
+    } catch (error) {
+      console.error('Error creating plan coffee option:', error)
+      throw new Error(
+        error.response?.data?.message || 'Failed to create plan coffee option'
+      )
+    }
+  },
+
+  update: async (id, data) => {
+    try {
+      const response = await api.put(`/api/PlanCoffeeOption/${id}`, data)
+      return response.data
+    } catch (error) {
+      console.error('Error updating plan coffee option:', error)
+      throw new Error(
+        error.response?.data?.message || 'Failed to update plan coffee option'
+      )
+    }
+  },
+
+  remove: async (id) => {
+    try {
+      const response = await api.delete(`/api/PlanCoffeeOption/${id}`)
+      return response.data
+    } catch (error) {
+      console.error('Error deleting plan coffee option:', error)
+      throw new Error(
+        error.response?.data?.message || 'Failed to delete plan coffee option'
+      )
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add routing and sidebar entry for PlanCoffeeOption
- implement PlanCoffeeOption page with CRUD operations
- create service for PlanCoffeeOption API interactions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adbea1909c8330a6177e85344786b8